### PR TITLE
PHP CS Fixerの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,11 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+->in(__DIR__);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder);


### PR DESCRIPTION
## 何を変更したか
`.gitignore`と`.php-cs-fixer.php`の2つのファイルを変更または追加しました。

## 変更内容
- `.gitignore`に`.php-cs-fixer.cache`を追加しました。これにより、PHP CS FixerのキャッシュファイルがGitに追跡されないようになりました。
- `.php-cs-fixer.php`を新規に作成しました。このファイルには、PHP CS Fixerの設定が含まれています。ここでは、PSR-2コーディング規約と短い配列構文を使用するように設定しています。

## 変更の理由
これらの変更により、コードの整形が自動化され、コーディング規約の一貫性が保たれます。

## 変更の影響
これらの変更により、PHPファイルが保存されるたびに自動的にコードが整形されます。

## どのように変更を行なったのか
以下のコマンドを実行して、PHP CS Fixerを設定しました:

```sh
composer require friendsofphp/php-cs-fixer
php-cs-fixer fix
```
以下の変更を行いました。

.gitignoreファイルに.php-cs-fixer.cacheを追加しました。これにより、PHP CS FixerのキャッシュファイルがGitに追跡されないようになりました。

```diff
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+.php-cs-fixer.cache
```

- .php-cs-fixer.phpファイルを新規に作成しました。このファイルには、PHP CS Fixerの設定が含まれています。

```diff
@@ -0,0 +1,11 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+->in(__DIR__);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder);
```

このファイルでは以下のような設定を行っています。

- PhpCsFixer\Finder::create()->in(__DIR__)：Finderインスタンスを作成し、現在のディレクトリ(__DIR__)内のPHPファイルを対象とします。
- new PhpCsFixer\Config()：新しいConfigインスタンスを作成します。
->setRules(['@PSR2' => true, 'array_syntax' => ['syntax' => 'short']])：PSR-2コーディング規約を適用し、配列構文を短い形式([])にします。
- ->setFinder($finder)：上記で作成したFinderインスタンスを設定します。

# 関連するIssueまたはPR
#15 により詳細

# スクリーンショット
# テスト
ローカル環境でPHPファイルを保存したときに、コードが自動的に整形されることを確認しました。



