### PR TITLE
デフォルトURLをlocalhost/#/に変更

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -77,7 +77,7 @@
      <script>
          window.onload = function() {
              window.location.hash = '#/';
-             history.replaceState('#/', document.title, window.location.pathname);
+             history.replaceState(null, document.title, window.location.pathname + '#/');
          };
      </script>
      <script src="{{ asset('/js/home/popularTagBtn.js') }}"></script>


### PR DESCRIPTION
# 何を変更したか
home.blade.phpのJavaScriptコードを変更し、localhostにアクセスした際に自動的にlocalhost/#/にリダイレクトするようにしました。

# 変更内容
以下のdiffを参照してください:

```diff
diff --git a/resources/views/home.blade.php b/resources/views/home.blade.php
index 9e53ecb..84131d7 100644
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -77,7 +77,7 @@
      <script>
          window.onload = function() {
              window.location.hash = '#/';
-             history.replaceState('#/', document.title, window.location.pathname);
+             history.replaceState(null, document.title, window.location.pathname + '#/');
          };
      </script>
      <script src="{{ asset('/js/home/popularTagBtn.js') }}"></script>
```
# 変更の理由
conduitの要件に合わせるために、デフォルトのURLをlocalhost/#/に変更する必要がありました。

# 変更の影響
ユーザーがlocalhostにアクセスすると、自動的にlocalhost/#/にリダイレクトされます。


# どのように変更を行なったのか
home.blade.phpに以下のJavaScriptコードを追加しました：

window.onload = function() {
    window.location.hash = '#/';
    history.replaceState(null, document.title, window.location.pathname + '#/');
};

# 関連するIssueまたはPR
#24
# スクリーンショット
# テスト
localhostにアクセスし、自動的にlocalhost/#/にリダイレクトされることを確認しました。


