### PR TITLE
ユーザーのログイン状態に応じてヘッダーを切り替える

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -24,12 +24,27 @@
                         <!-- Add "active" class when you're on that page" -->
                         <a class="nav-link active" href="/">Home</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/login">Sign in</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/register">Sign up</a>
-                    </li>
+                    @if (Auth::check())
+                        <li class="nav-item">
+                            <a class="nav-link" href="/editor"> <i class="ion-compose"></i>&nbsp;New Article </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/settings"> <i class="ion-gear-a"></i>&nbsp;Settings </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/profile/eric-simons">
+                                <img src="" class="user-pic" />
+                                {{ Auth::user()->name }}
+                            </a>
+                        </li>
+                    @else
+                        <li class="nav-item">
+                            <a class="nav-link" href="/login">Sign in</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/register">Sign up</a>
+                        </li>
+                    @endif
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
# 何を変更したか
guest.blade.phpを変更し、ユーザーのログイン状態に応じてヘッダーの表示を切り替えるようにしました。

# 変更内容
以下のdiffを参照してください：

```diff
diff --git a/resources/views/layouts/guest.blade.php b/resources/views/layouts/guest.blade.php
index 2b3dd0e..cf1abf1 100644
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -24,12 +24,27 @@
                         <!-- Add "active" class when you're on that page" -->
                         <a class="nav-link active" href="/">Home</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/login">Sign in</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/register">Sign up</a>
-                    </li>
+                    @if (Auth::check())
+                        <li class="nav-item">
+                            <a class="nav-link" href="/editor"> <i class="ion-compose"></i>&nbsp;New Article </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/settings"> <i class="ion-gear-a"></i>&nbsp;Settings </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/profile/eric-simons">
+                                <img src="" class="user-pic" />
+                                {{ Auth::user()->name }}
+                            </a>
+                        </li>
+                    @else
+                        <li class="nav-item">
+                            <a class="nav-link" href="/login">Sign in</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/register">Sign up</a>
+                        </li>
+                    @endif
                 </ul>
             </div>
         </nav>
```

# 変更の理由
ユーザーがログインまたは登録した後、ヘッダーが切り替わることで、ユーザーが自分のログイン状態を一目で確認できます。


# 変更の影響
ユーザーがログインしている場合、ヘッダーには"New Article"、"Settings"、およびユーザー名が表示されます。ユーザーがログインしていない場合、ヘッダーには"Sign in"と"Sign up"のリンクが表示されます。


# どのように変更を行なったのか
guest.blade.phpにAuth::check()を使用してユーザーのログイン状態を確認し、ログインしている場合とログインしていない場合で表示するヘッダーを切り替えました。


# 関連するIssueまたはPR
#28 
# スクリーンショット
# テスト
ログインしていない状態でウェブサイトにアクセスし、ヘッダーに"Sign in"と"Sign up"のリンクが表示されることを確認します。次に、ログインまたは登録した後、ヘッダーに"New Article"、"Settings"、およびユーザー名が表示されることを確認します。

